### PR TITLE
fix(excel): 人員不足の赤色表示が休日の黄色で上書きされないよう修正

### DIFF
--- a/src/io/export_excel.py
+++ b/src/io/export_excel.py
@@ -94,7 +94,10 @@ def export_schedule_to_excel(
 
         if is_holiday_or_weekend(d):  # -> bool を返すよう定義側も注釈
             for col in range(1, 3 + len(hospital_names)):
-                ws.cell(row=i, column=col).fill = holiday_fill
+                c = ws.cell(row=i, column=col)
+                # 人員不足(赤)は休日(黄)より優先
+                if c.fill != shortage_fill:
+                    c.fill = holiday_fill
 
         for col in range(1, 3 + len(hospital_names)):
             ws.cell(row=i, column=col).border = border


### PR DESCRIPTION
休日/週末の黄色塗りつぶしを適用する前に、セルが既に人員不足の
赤色塗りつぶしを持っているかチェックし、赤色を優先するよう変更。

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
