### PR TITLE
fix(hospitals_editor): シフト表のダブルクリックで編集ダイアログを表示

### DIFF
--- a/src/gui/editors/hospitals_editor.py
+++ b/src/gui/editors/hospitals_editor.py
@@ -196,7 +196,9 @@ class HospitalDialog(QDialog):
         self.shift_table.setHorizontalHeaderLabels(["shift_type", "weekdays", "frequency"])
         self.shift_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.shift_table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.shift_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.shift_table.horizontalHeader().setStretchLastSection(True)
+        self.shift_table.itemDoubleClicked.connect(lambda _: self._edit_shift())
 
         btn_shift_add = QPushButton("シフト新規追加")
         btn_shift_edit = QPushButton("シフト編集")


### PR DESCRIPTION
シフト表のセルを直接編集できないようNoEditTriggersを設定し、
ダブルクリック時にShiftDialogを開くよう変更。

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
