### PR TITLE
refactor(gui): エディタ共通ファイル操作を基底クラスに集約

### DIFF
--- a/src/gui/common/base_editor.py
+++ b/src/gui/common/base_editor.py
@@ -1,0 +1,52 @@
+"""Editor windows base class -- common file operation slots."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QMainWindow,
+    QMessageBox,
+    QWidget,
+)
+
+
+class BaseEditorWindow(QMainWindow):
+    """エディタウィンドウ共通基底. _on_open / _on_save / _on_save_as を提供する.
+
+    サブクラスは以下を定義すること:
+    - _file_filter: str  (例: "CSV (*.csv)")
+    - open_path(path) -> None
+    - save_to(path) -> None
+    """
+
+    _file_filter: str = ""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.current_path: Path | None = None
+
+    def open_path(self, path: Path) -> None:
+        raise NotImplementedError
+
+    def save_to(self, path: Path) -> None:
+        raise NotImplementedError
+
+    def _on_open(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Open", "", self._file_filter)
+        if path:
+            self.open_path(Path(path))
+
+    def _on_save(self) -> None:
+        if self.current_path is None:
+            self._on_save_as()
+            return
+        self.save_to(self.current_path)
+        QMessageBox.information(self, "保存完了", f"{self.current_path.name} を保存しました。")
+
+    def _on_save_as(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Save As", "", self._file_filter)
+        if path:
+            self.save_to(Path(path))
+            QMessageBox.information(self, "保存完了", f"{Path(path).name} を保存しました。")

--- a/src/gui/editors/csv_editor.py
+++ b/src/gui/editors/csv_editor.py
@@ -10,11 +10,9 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QBrush, QColor
 from PySide6.QtWidgets import (
-    QFileDialog,
     QFrame,
     QHBoxLayout,
     QInputDialog,
-    QMainWindow,
     QMessageBox,
     QPushButton,
     QTableWidget,
@@ -23,18 +21,20 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from src.gui.common.base_editor import BaseEditorWindow
 from src.io.max_assignments_loader import load_max_assignments_csv
 from src.io.max_assignments_writer import dump_max_assignments_csv
 
 
-class CsvEditorWindow(QMainWindow):
+class CsvEditorWindow(BaseEditorWindow):
     """max-assignments.csv を QTableWidget で編集するウィンドウ."""
+
+    _file_filter = "CSV (*.csv)"
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("CSV Editor")
         self.resize(900, 600)
-        self.current_path: Path | None = None
 
         self._table = QTableWidget()
 
@@ -173,32 +173,6 @@ class CsvEditorWindow(QMainWindow):
         return data
 
     # --- private ---
-    def _on_open(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Open CSV", "", "CSV (*.csv)")
-        if path:
-            self.open_path(Path(path))
-
-    def _on_save(self) -> None:
-        if self.current_path is None:
-            self._on_save_as()
-            return
-        self.save_to(self.current_path)
-        QMessageBox.information(
-            self,
-            "\u4fdd\u5b58\u5b8c\u4e86",
-            f"{self.current_path.name} \u3092\u4fdd\u5b58\u3057\u307e\u3057\u305f\u3002",
-        )
-
-    def _on_save_as(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save As", "", "CSV (*.csv)")
-        if path:
-            self.save_to(Path(path))
-            QMessageBox.information(
-                self,
-                "\u4fdd\u5b58\u5b8c\u4e86",
-                f"{Path(path).name} \u3092\u4fdd\u5b58\u3057\u307e\u3057\u305f\u3002",
-            )
-
     def _on_add_row(self) -> None:
         """入力ダイアログで名前を受け取り, 選択行の下に挿入する. 未選択なら末尾."""
         name, ok = QInputDialog.getText(self, "行追加", "名前:")

--- a/src/gui/editors/hospitals_editor.py
+++ b/src/gui/editors/hospitals_editor.py
@@ -14,7 +14,6 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,
-    QFileDialog,
     QFormLayout,
     QGridLayout,
     QGroupBox,
@@ -23,7 +22,6 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QListWidgetItem,
-    QMainWindow,
     QMessageBox,
     QPushButton,
     QTableWidget,
@@ -34,6 +32,7 @@ from PySide6.QtWidgets import (
 from tomlkit import aot, document, parse, table
 
 from src.domain.types import Frequency, Hospital, HospitalDemandRule, ShiftType, Weekday
+from src.gui.common.base_editor import BaseEditorWindow
 
 # ---------------------------------------------------------------------------
 # Constants (derived from domain enums)
@@ -325,14 +324,15 @@ class HospitalDialog(QDialog):
 # ---------------------------------------------------------------------------
 # Main editor window
 # ---------------------------------------------------------------------------
-class HospitalsEditorWindow(QMainWindow):
+class HospitalsEditorWindow(BaseEditorWindow):
     """hospitals.toml GUI editor -- list + detail + dialogs."""
+
+    _file_filter = "TOML (*.toml)"
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Hospitals Editor")
         self.resize(1100, 650)
-        self.current_path: Path | None = None
         self.doc: tomlkit.TOMLDocument = document()
 
         # -- left: hospital list --
@@ -563,22 +563,3 @@ class HospitalsEditorWindow(QMainWindow):
         row = self.list_hosp.currentRow()
         if 0 <= row < len(self._hospitals()) - 1:
             self._swap_hospitals(row, row + 1)
-
-    # -- file operations --
-    def _on_open(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Open TOML", "", "TOML (*.toml)")
-        if path:
-            self.open_path(Path(path))
-
-    def _on_save(self) -> None:
-        if self.current_path is None:
-            self._on_save_as()
-            return
-        self.save_to(self.current_path)
-        QMessageBox.information(self, "保存完了", f"{self.current_path.name} を保存しました。")
-
-    def _on_save_as(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save As", "", "TOML (*.toml)")
-        if path:
-            self.save_to(Path(path))
-            QMessageBox.information(self, "保存完了", f"{Path(path).name} を保存しました。")

--- a/src/gui/editors/specified_editor.py
+++ b/src/gui/editors/specified_editor.py
@@ -13,19 +13,18 @@ from PySide6.QtCore import QDate, QRect, Qt
 from PySide6.QtGui import QColor, QPainter, QPen
 from PySide6.QtWidgets import (
     QCalendarWidget,
-    QFileDialog,
     QHBoxLayout,
     QInputDialog,
     QLabel,
     QListWidget,
     QListWidgetItem,
-    QMainWindow,
     QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,
 )
 
+from src.gui.common.base_editor import BaseEditorWindow
 from src.gui.editors.workers_editor import load_hospital_choices
 from src.io.specified_days_loader import load_specified_days
 from src.io.specified_days_writer import dump_specified_days
@@ -130,14 +129,15 @@ class _MonthCalendar(QCalendarWidget):
 # ---------------------------------------------------------------------------
 # GUI
 # ---------------------------------------------------------------------------
-class SpecifiedDatesEditorWindow(QMainWindow):
+class SpecifiedDatesEditorWindow(BaseEditorWindow):
     """specified-dates.toml GUI editor -- hospital list + calendar."""
+
+    _file_filter = "TOML (*.toml)"
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Specified Dates Editor")
         self.resize(900, 600)
-        self.current_path: Path | None = None
         self._model: dict[str, set[int]] = {}
         self._hospitals_path: Path | None = None
 
@@ -322,30 +322,3 @@ class SpecifiedDatesEditorWindow(QMainWindow):
         name = self._current_hospital_name()
         days = self._model[name] if name is not None else set()
         self._calendar.set_highlight_dates(days)
-
-    # -- file operations --
-    def _on_open(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Open TOML", "", "TOML (*.toml)")
-        if path:
-            self.open_path(Path(path))
-
-    def _on_save(self) -> None:
-        if self.current_path is None:
-            self._on_save_as()
-            return
-        self.save_to(self.current_path)
-        QMessageBox.information(
-            self,
-            "\u4fdd\u5b58\u5b8c\u4e86",
-            f"{self.current_path.name} \u3092\u4fdd\u5b58\u3057\u307e\u3057\u305f\u3002",
-        )
-
-    def _on_save_as(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save As", "", "TOML (*.toml)")
-        if path:
-            self.save_to(Path(path))
-            QMessageBox.information(
-                self,
-                "\u4fdd\u5b58\u5b8c\u4e86",
-                f"{Path(path).name} \u3092\u4fdd\u5b58\u3057\u307e\u3057\u305f\u3002",
-            )

--- a/src/gui/editors/workers_editor.py
+++ b/src/gui/editors/workers_editor.py
@@ -12,7 +12,6 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,
-    QFileDialog,
     QFormLayout,
     QGridLayout,
     QGroupBox,
@@ -20,7 +19,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QListWidget,
-    QMainWindow,
     QMessageBox,
     QPushButton,
     QSplitter,
@@ -29,6 +27,7 @@ from PySide6.QtWidgets import (
 )
 
 from src.domain.types import ShiftType, Weekday, Worker, WorkerAssignmentRule
+from src.gui.common.base_editor import BaseEditorWindow
 from src.gui.editors.hospitals_editor import SHIFT_TYPES, WEEKDAYS
 from src.io.hospitals_loader import load_hospitals
 from src.io.workers_loader import load_workers
@@ -155,14 +154,15 @@ class AssignmentDialog(QDialog):
 # ---------------------------------------------------------------------------
 # GUI
 # ---------------------------------------------------------------------------
-class WorkersEditorWindow(QMainWindow):
+class WorkersEditorWindow(BaseEditorWindow):
     """workers.toml editor window (worker list + detail form with assignment list)."""
+
+    _file_filter = "TOML (*.toml)"
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Workers Editor")
         self.resize(900, 600)
-        self.current_path: Path | None = None
         self._model: list[Worker] = []
         self._current_index: int = -1
         self._hospitals_path: Path | None = None
@@ -384,22 +384,3 @@ class WorkersEditorWindow(QMainWindow):
             return
         w.assignments.pop(arow)
         self._assignments_list.takeItem(arow)
-
-    # --- private: file operation slots ---
-    def _on_open(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Open TOML", "", "TOML (*.toml)")
-        if path:
-            self.open_path(Path(path))
-
-    def _on_save(self) -> None:
-        if self.current_path is None:
-            self._on_save_as()
-            return
-        self.save_to(self.current_path)
-        QMessageBox.information(self, "保存完了", f"{self.current_path.name} を保存しました。")
-
-    def _on_save_as(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save As", "", "TOML (*.toml)")
-        if path:
-            self.save_to(Path(path))
-            QMessageBox.information(self, "保存完了", f"{Path(path).name} を保存しました。")


### PR DESCRIPTION
## Summary
- `BaseEditorWindow(QMainWindow)` 基底クラスを `src/gui/common/base_editor.py` に新設
- 4つのエディタで重複していた `_on_open` / `_on_save` / `_on_save_as` を基底クラスに集約 (約100行削減)
- 各エディタは `_file_filter` クラス属性と `open_path` / `save_to` を定義するだけで済む構造に

## Test plan
- [x] `uv run pytest tests/` で全266テストがパス
- [x] mypy, ruff-check, ruff-format すべてパス
- [x] 各エディタ(CSV / Hospitals / Workers / Specified Dates)のOpen/Save/SaveAs操作が正常に動作することを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)