### PR TITLE
docs: fix typo in summarize_penalties docstring

### DIFF
--- a/src/optimizer/report.py
+++ b/src/optimizer/report.py
@@ -10,7 +10,7 @@ def summarize_penalties(
     ctx: Context, sources: list[str] | None = None
 ) -> tuple[float, dict[str, float], list[dict[str, Any]]]:
     """
-    ctx["penaltcies"] を集計して (total, by_source, rows) を返す。
+    ctx["penalties"] を集計して (total, by_source, rows) を返す。
     rows は {"source","var","value","weight","penalty",**meta} の辞書列。
     """
     rows = []


### PR DESCRIPTION
## 概要

`summarize_penalties` のdocstring内のタイポを修正する。
`penaltcies` → `penalties`

## 変更内容

- `src/optimizer/report.py`: docstringのスペルミスを修正

## 動作確認

- pre-commitフック（ruff-check, ruff-format, mypy）がすべてパス済み